### PR TITLE
bump tensorflow-gpu version to 2.4.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,6 @@ sklearn==0.0
 six==1.15.0
 tqdm==4.50.2
 Pillow==8.0.0
-tensorflow-gpu>=2.3.1
+tensorflow-gpu>=2.4.0
 tensorflow-addons>=0.11.2
 tensorflow-datasets>=4.0.1


### PR DESCRIPTION
Bumps the tensorflow-gpu version in requirements.txt to 2.4.0, this fixes the bug described in issue #4 